### PR TITLE
fix compatibility with minimap

### DIFF
--- a/styles/main.less
+++ b/styles/main.less
@@ -1,7 +1,7 @@
 @import "ui-variables";
 @import "syntax-variables";
 
-atom-text-editor.editor {
+atom-text-editor.editor .line-numbers {
   .relative.current-line {
     // Add some color to make the current line stand out.
     color: @text-color-info


### PR DESCRIPTION
this PR scopes `.absolute` styles for this package so that it doesn't clobber other packages' styles elsewhere in the window.

Without this change, minimap in absolute mode is broken if `relative-numbers` is enabled